### PR TITLE
総作業時間に関するカラム名、表記の修正

### DIFF
--- a/app/Domain/Project/ProjectListStatQueryBuilder.php
+++ b/app/Domain/Project/ProjectListStatQueryBuilder.php
@@ -35,7 +35,7 @@ class ProjectListStatQueryBuilder
             . '      select project_id, count(*) as count from tasks where status=:completed_status group by project_id'
             . ' ) completed_tasks on (completed_tasks.project_id=projects.id) '
             . ' left join ('
-            . '     select project_id, sum(estimate_minutes) as total from tasks group by project_id '
+            . '     select project_id, sum(estimate_hours) as total from tasks group by project_id '
             . ' ) estimate_hours_total on (estimate_hours_total.project_id=projects.id)'
             . ' left join task_logs on task_logs.task_id=tasks.id '
             . ' where projects.id in (' . implode(',', $projectIds) . ')'

--- a/app/Domain/Project/ProjectListStatQueryBuilder.php
+++ b/app/Domain/Project/ProjectListStatQueryBuilder.php
@@ -28,7 +28,7 @@ class ProjectListStatQueryBuilder
         $sql = 'select projects.id, count(distinct tasks.id) as task_count, '
             . '     completed_tasks.count as completed_task_count, '
             . '     sum(task_logs.hours) as total_result_hours, '
-            . '     estimate_hours_total.total as total_estimated_hours '
+            . '     estimate_hours_total.total as total_estimate_hours '
             . ' from projects '
             . ' left join tasks on (tasks.project_id=projects.id) '
             . ' left join ('
@@ -55,7 +55,7 @@ class ProjectListStatQueryBuilder
                     'task_count'            => $projectStats[$project->id]->task_count,
                     'completed_task_count'  => $projectStats[$project->id]->completed_task_count,
                     'total_result_hours'    => $projectStats[$project->id]->total_result_hours,
-                    'total_estimated_hours' => $projectStats[$project->id]->total_estimated_hours,
+                    'total_estimate_hours' => $projectStats[$project->id]->total_estimate_hours,
                 ],
             ];
         });

--- a/app/Domain/Task/Task.php
+++ b/app/Domain/Task/Task.php
@@ -27,7 +27,7 @@ class Task extends Model
         'description',
         'start_date',
         'end_date',
-        'estimate_minutes',
+        'estimate_hours',
         'actual_minutes',
         'status',
     ];

--- a/app/Http/Controllers/TaskApiController.php
+++ b/app/Http/Controllers/TaskApiController.php
@@ -154,7 +154,7 @@ class TaskApiController extends Controller
                 $task->id => [
                     'id' => $task->id,
                     'title' => $task->title,
-                    'estimate_minutes' => $task->estimate_minutes,
+                    'estimate_hours' => $task->estimate_hours,
                     'actual_time' => $task->getActualTime(),
                     'end_date' => $task->end_date,
                 ]
@@ -171,7 +171,7 @@ class TaskApiController extends Controller
                 $task->id => [
                     'id' => $task->id,
                     'title' => $task->title,
-                    'estimate_minutes' => $task->estimate_minutes,
+                    'estimate_hours' => $task->estimate_hours,
                     'actual_time' => $task->getActualTime(),
                     'end_date' => $task->end_date,
                 ]

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -17,7 +17,7 @@ $factory->define(WorkLogger\Domain\Task\Task::class, function (Faker $faker) {
         'issue_no'         => $faker->numerify('Issue-####'),
         'title'            => $faker->title,
         'description'      => $faker->lexify('説明文 ???????'),
-        'estimate_minutes' => $faker->numberBetween(30, 240),
+        'estimate_hours'   => $faker->numberBetween(30, 240),
         'actual_minutes'   => 0,
         'status'           => array_rand([
             Task::STATE_NONE,

--- a/database/migrations/2020_03_26_012051_modify_tasks_estimate_minutes_to_hours.php
+++ b/database/migrations/2020_03_26_012051_modify_tasks_estimate_minutes_to_hours.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyTasksEstimateMinutesToHours extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn('estimate_minutes', 'estimate_hours');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->renameColumn('estimate_hours', 'estimate_minutes');
+        });
+    }
+}

--- a/resources/js/adapters/dashboard-adapter.js
+++ b/resources/js/adapters/dashboard-adapter.js
@@ -15,7 +15,7 @@ class DashboardAdapter {
             'task_count',
             'completed_task_count',
             'total_result_hours',
-            'total_estimated_hours'
+            'total_estimate_hours'
           ])
         }]
       })

--- a/resources/js/adapters/project-adapter.js
+++ b/resources/js/adapters/project-adapter.js
@@ -15,7 +15,7 @@ class ProjectAdapter {
             'task_count',
             'completed_task_count',
             'total_result_hours',
-            'total_estimated_hours',
+            'total_estimate_hours',
             'updated_at'
           ])
         }]

--- a/resources/js/adapters/task-adapter.js
+++ b/resources/js/adapters/task-adapter.js
@@ -10,7 +10,7 @@ class TaskAdapter {
         description: task.description,
         start_date: task.start_date,
         end_date: task.end_date,
-        estimate_minutes: task.estimate_minutes,
+        estimate_hours: task.estimate_hours,
         status: task.status
       }
     )
@@ -25,7 +25,7 @@ class TaskAdapter {
       description: task.description,
       start_date: task.start_date,
       end_date: task.end_date,
-      estimate_minutes: task.estimate_minutes,
+      estimate_hours: task.estimate_hours,
       status: task.status
     })
 

--- a/resources/js/pages/dashboard/project-list.vue
+++ b/resources/js/pages/dashboard/project-list.vue
@@ -23,7 +23,7 @@
           {{ hours(project.total_result_hours) }}h
         </td>
         <td class="col-total-estimate-hours" data-test="col-total-estimate-hours">
-          {{ hours(project.total_estimated_hours) }}h
+          {{ hours(project.total_estimate_hours) }}h
         </td>
       </tr>
     </table>

--- a/resources/js/pages/dashboard/task-list.vue
+++ b/resources/js/pages/dashboard/task-list.vue
@@ -22,7 +22,7 @@
           {{ formatDate(task.end_date) }}
         </td>
         <td class="col-task-stat">
-          {{ task.actual_time }} / {{ task.estimate_minutes }}h
+          {{ task.actual_time }} / {{ task.estimate_hours }}h
         </td>
       </tr>
     </table>

--- a/resources/js/pages/project/in-progress-task-list.vue
+++ b/resources/js/pages/project/in-progress-task-list.vue
@@ -14,7 +14,7 @@
                 </router-link>
               </td>
               <td class="col-number">
-                {{ task.estimate_minutes }}h
+                {{ task.estimate_hours }}h
               </td>
               <td class="col-icons">
                 <a

--- a/resources/js/pages/project/project-list-container.vue
+++ b/resources/js/pages/project/project-list-container.vue
@@ -46,7 +46,7 @@
                     }}h
                   </td>
                   <td class="col-total-estimate-hours">
-                    {{ project.total_estimated_hours }}
+                    {{ project.total_estimate_hours }}
                   </td>
                   <td class="col-date-time">
                     {{ project.updated_at | format_date('YYYY-MM-DD HH:mm:ss') }}
@@ -61,7 +61,6 @@
     <ProjectFormContainer
       ref="projectForm"
     />
-    </projectformcontainer>
   </div>
 </template>
 

--- a/resources/js/pages/project/scheduled-task-list.vue
+++ b/resources/js/pages/project/scheduled-task-list.vue
@@ -14,7 +14,7 @@
                 </router-link>
               </td>
               <td class="col-number">
-                {{ task.estimate_minutes }}h
+                {{ task.estimate_hours }}h
               </td>
               <td class="col-icons">
                 <a

--- a/resources/js/pages/tasks/task-detail.vue
+++ b/resources/js/pages/tasks/task-detail.vue
@@ -32,7 +32,7 @@
       <div class="detail-row">
         <label>実績(予定工数)</label>
         <div class="detail-col">
-          {{ task.actual_time }}h(予定: {{ task.estimate_minutes }}h)
+          {{ task.actual_time }}h(予定: {{ task.estimate_hours }}h)
         </div>
       </div>
       <div class="detail-row">

--- a/resources/js/pages/tasks/task-form-container.vue
+++ b/resources/js/pages/tasks/task-form-container.vue
@@ -48,7 +48,7 @@ export default {
           title: '',
           start_date: '',
           end_date: '',
-          estimate_minutes: 0,
+          estimate_hours: 0,
           status: 0
         }
       } else {

--- a/resources/js/pages/tasks/task-form.vue
+++ b/resources/js/pages/tasks/task-form.vue
@@ -119,17 +119,17 @@
         </div>
         <div class="col">
           <input
-            v-model="task.estimate_minutes"
+            v-model="task.estimate_hours"
             v-validate="'required|min_value:0.1'"
             type="number"
-            name="estimate_minutes"
+            name="estimate_hours"
             data-vv-as="予定工数"
             class="text-box estimate-time"
           >
           <ul class="errors">
             <li
               v-for="(error, index) in errors.collect(
-                'estimate_minutes'
+                'estimate_hours'
               )"
               :key="index"
             >

--- a/tests/Unit/Domain/Project/ProjectListStatQueryBuilderTest.php
+++ b/tests/Unit/Domain/Project/ProjectListStatQueryBuilderTest.php
@@ -181,8 +181,8 @@ class ProjectListStatQueryBuilderTest extends TestCase
 
         $result = $this->queryBuilder->getProjectList($user);
 
-        $this->assertEquals(1.4 * 3, $result[$projects[0]->id]['total_estimated_hours']);
-        $this->assertEquals(2, $result[$projects[1]->id]['total_estimated_hours']);
+        $this->assertEquals(1.4 * 3, $result[$projects[0]->id]['total_estimate_hours']);
+        $this->assertEquals(2, $result[$projects[1]->id]['total_estimate_hours']);
     }
 
 
@@ -210,7 +210,7 @@ class ProjectListStatQueryBuilderTest extends TestCase
 
         $result = $this->queryBuilder->getProjectList($user);
 
-        $this->assertEquals(1.4 * 3, $result[$projects[0]->id]['total_estimated_hours']);
-        $this->assertEquals(2, $result[$projects[1]->id]['total_estimated_hours']);
+        $this->assertEquals(1.4 * 3, $result[$projects[0]->id]['total_estimate_hours']);
+        $this->assertEquals(2, $result[$projects[1]->id]['total_estimate_hours']);
     }
 }

--- a/tests/Unit/Domain/Project/ProjectListStatQueryBuilderTest.php
+++ b/tests/Unit/Domain/Project/ProjectListStatQueryBuilderTest.php
@@ -171,12 +171,12 @@ class ProjectListStatQueryBuilderTest extends TestCase
         $projects[1]->users()->save($user);
 
         factory(Task::class, 3)->create([
-            'project_id'       => $projects[0]->id,
-            'estimate_minutes' => 1.4,
+            'project_id'     => $projects[0]->id,
+            'estimate_hours' => 1.4,
         ]);
         factory(Task::class, 1)->create([
-            'project_id'       => $projects[1]->id,
-            'estimate_minutes' => 2,
+            'project_id'     => $projects[1]->id,
+            'estimate_hours' => 2,
         ]);
 
         $result = $this->queryBuilder->getProjectList($user);
@@ -197,12 +197,12 @@ class ProjectListStatQueryBuilderTest extends TestCase
         $projects[1]->users()->save($user);
 
         $tasks = factory(Task::class, 3)->create([
-            'project_id'       => $projects[0]->id,
-            'estimate_minutes' => 1.4,
+            'project_id'     => $projects[0]->id,
+            'estimate_hours' => 1.4,
         ]);
         factory(Task::class, 1)->create([
-            'project_id'       => $projects[1]->id,
-            'estimate_minutes' => 2,
+            'project_id'     => $projects[1]->id,
+            'estimate_hours' => 2,
         ]);
         factory(TaskLog::class, 2)->create([
             'task_id' => $tasks[0]->id,

--- a/tests/js/pages/dashboard/project-list.spec.js
+++ b/tests/js/pages/dashboard/project-list.spec.js
@@ -82,7 +82,7 @@ describe('ProjectList', () => {
     test('4列目:総見積時間', async () => {
       const totalEstimatedHours = 5.5
       const project = createProject({
-        total_estimated_hours: totalEstimatedHours
+        total_estimate_hours: totalEstimatedHours
       })
       const wrapper = createProjectList({
         [project.id]: project


### PR DESCRIPTION
#380, #381 関連
総作業時間は時間(H)で保持しているものの、カラム名や表記が"分"になっている個所があるため修正する。
