### PR TITLE
タスクの簡易選択機能を、モーダルを開かずに選択するように変更。

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
         "test-watch": "node ./node_modules/jest/bin/jest.js --watch",
         "lint-all": "eslint --ignore-path=.gitignore --ext=.js resources/js"
     },
-    "devDependencies": {},
+    "devDependencies": {
+        "flush-promises": "^1.0.2"
+    },
     "dependencies": {
         "@babel/core": "^7.8.7",
         "@babel/polyfill": "^7.8.7",

--- a/resources/js/pages/dashboard/dashboard-container.vue
+++ b/resources/js/pages/dashboard/dashboard-container.vue
@@ -5,72 +5,11 @@
     </h1>
 
     <div class="frame-list clear-fix">
-      <WlFrame size="xl">
-        <template slot="title">
-          現在のタスク
-        </template>
-        <template slot="body">
-          <div class="form form-align-left">
-            <div class="row">
-              <div class="col-label label-width-3">
-                プロジェクト名:
-              </div>
-              <div class="col input-width-2">
-                <WlSuggest
-                  :value="activeProjectId"
-                  :text="activeProjectName"
-                  :suggest-callback="loadSuggestions"
-                  @selected="handleProjectSelected"
-                />
-              </div>
-              <div class="col-label label-width-2">
-                タスク名:
-              </div>
-              <div class="col input-width-2">
-                <WlSuggest
-                  ref="taskSuggest"
-                  :value="activeTaskId"
-                  :text="activeTaskName"
-                  :suggest-callback="loadTaskSuggestions"
-                  :disabled="!canEditTask"
-                  @selected="handleTaskSelected"
-                />
-              </div>
-            </div>
-          </div>
-
-          <WlSubFrame size="s">
-            <template slot="title">
-              実績
-            </template>
-            <template slot="body">
-              <div class="form form-align-left">
-                <div class="row">
-                  <div class="col-label label-width-2">
-                    作業時間:
-                  </div>
-                  <div class="col input-width-2">
-                    <input v-model="resultHours" type="number" class="text-box" size="5" :disabled="!canInputResult"> min
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-label label-width-2">
-                    メモ:
-                  </div>
-                  <div class="col input-width-2">
-                    <textarea v-model="resultMemo" class="text-box" style="width: 90%; height: 60px;" :disabled="!canInputResult" />
-                  </div>
-                </div>
-                <div class="row row-align-right">
-                  <button class="button" :disabled="!canRegisterResult" @click="handleRegisterResult">
-                    登録
-                  </button>
-                </div>
-              </div>
-            </template>
-          </WlSubFrame>
-        </template>
-      </Wlframe>
+      <TaskSelect
+        :load-suggestions="loadSuggestions"
+        :load-task-suggestions="loadTaskSuggestions"
+        @register-result="handleRegisterResult"
+      />
     </div>
 
     <div class="frame-list clear-fix">
@@ -125,14 +64,6 @@
       ref="projectFormContainer"
       @projectSaved="handleProjectSaved"
     />
-    <TaskSelectPopupContainer
-      ref="taskSelectPopupContainer"
-      :active-project-id="activeProjectId"
-      :active-project-name="activeProjectName"
-      :active-task-id="activeTaskId"
-      :active-task-name="activeTaskName"
-      @setProjectAndTask="handleSetProjectAndTask"
-    />
   </div>
 </template>
 
@@ -140,48 +71,26 @@
 import ProjectFormContainer from '../project/project-form-container'
 import ProjectList from './project-list'
 import TaskList from './task-list'
-import TaskSelectPopupContainer from './task-select-popup-container'
+import TaskSelect from './task-select'
 import WlFrame from '../../components/wl-frame'
 import WlLoadingProxy from '../../components/wl-loading-proxy'
-import WlSubFrame from '../../components/wl-sub-frame'
-import WlSuggest from '../../components/form/wl-suggest'
 import adapterFactory from '../../adapters/adapter-factory'
 
 export default {
   components: {
     WlFrame,
     WlLoadingProxy,
-    WlSubFrame,
-    WlSuggest,
     ProjectFormContainer,
     ProjectList,
     TaskList,
-    TaskSelectPopupContainer
+    TaskSelect,
   },
   data () {
     return {
-      activeProjectId: 0,
-      activeTaskId: 0,
-      activeProjectName: '',
-      activeTaskName: '',
       projects: [],
       projectTaskCountList: {},
       nearDeadlineTasks: {},
       inProgressTasks: {},
-      resultHours: 0.0,
-      resultMemo: '',
-    }
-  },
-
-  computed: {
-    canInputResult () {
-      return this.activeTaskId !== 0
-    },
-    canRegisterResult () {
-      return this.activeTaskId !== 0 && this.resultHours > 0
-    },
-    canEditTask () {
-      return this.activeProjectId !== 0
     }
   },
 
@@ -206,24 +115,9 @@ export default {
       const dashboardAdapter = adapterFactory.get('DashboardAdapter')
       return dashboardAdapter.getProjectSuggestionList(keyword)
     },
-    async loadTaskSuggestions (keyword) {
+    async loadTaskSuggestions (projectId, keyword) {
       const dashboardAdapter = adapterFactory.get('DashboardAdapter')
-      return dashboardAdapter.getTaskSuggestionList(this.activeProjectId, keyword)
-    },
-
-    handleProjectSelected (payload) {
-      this.activeProjectId = payload.value
-      this.activeProjectName = payload.text
-
-      if (this.activeProjectId === 0) {
-        this.activeTaskId = 0
-        this.activeTaskName = ''
-        this.$refs.taskSuggest.init('', 0)
-      }
-    },
-    handleTaskSelected (payload) {
-      this.activeTaskId = payload.value
-      this.activeTaskName = payload.text
+      return dashboardAdapter.getTaskSuggestionList(projectId, keyword)
     },
 
     handleOpenNewProjectForm () {
@@ -241,14 +135,14 @@ export default {
       this.activeTaskId = payload.taskId
       this.activeTaskName = payload.taskName
     },
-    async handleRegisterResult () {
+    async handleRegisterResult (payload, onDone) {
       const dashboardAdapter = adapterFactory.get('DashboardAdapter')
-      await dashboardAdapter.registerResult(this.activeTaskId, {
-        hours: this.resultHours,
-        memo: this.resultMemo,
+      await dashboardAdapter.registerResult(payload.taskId, {
+        hours: payload.resultHours,
+        memo: payload.resultMemo,
       })
-      this.resultHours = 0
-      this.resultMemo = ''
+
+      onDone()
     }
   }
 }

--- a/resources/js/pages/dashboard/dashboard-container.vue
+++ b/resources/js/pages/dashboard/dashboard-container.vue
@@ -218,7 +218,7 @@ export default {
       if (this.activeProjectId === 0) {
         this.activeTaskId = 0
         this.activeTaskName = ''
-        // this.$refs.taskSuggest.init('', 0)
+        this.$refs.taskSuggest.init('', 0)
       }
     },
     handleTaskSelected (payload) {

--- a/resources/js/pages/dashboard/dashboard-container.vue
+++ b/resources/js/pages/dashboard/dashboard-container.vue
@@ -17,7 +17,6 @@
               </div>
               <div class="col input-width-2">
                 <WlSuggest
-                  class="input-width-3"
                   :value="activeProjectId"
                   :text="activeProjectName"
                   :suggest-callback="loadSuggestions"
@@ -30,7 +29,6 @@
               <div class="col input-width-2">
                 <WlSuggest
                   ref="taskSuggest"
-                  class="input-width-3"
                   :value="activeTaskId"
                   :text="activeTaskName"
                   :suggest-callback="loadTaskSuggestions"

--- a/resources/js/pages/dashboard/task-select-popup-container.vue
+++ b/resources/js/pages/dashboard/task-select-popup-container.vue
@@ -7,31 +7,13 @@
             <div class="col-label label-width-2">
               プロジェクト
             </div>
-            <div class="col">
-              <WlSuggest
-                class="input-width-3"
-                :value="projectId"
-                :text="projectName"
-                :suggest-callback="loadSuggestions"
-                @selected="handleProjectSelected"
-              />
-            </div>
+            <div class="col" />
           </div>
           <div class="row">
             <div class="col-label label-width-2">
               タスク
             </div>
-            <div class="col">
-              <WlSuggest
-                ref="taskSuggest"
-                class="input-width-3"
-                :value="taskId"
-                :text="taskName"
-                :suggest-callback="loadTaskSuggestions"
-                :disabled="!canEditTask"
-                @selected="handleTaskSelected"
-              />
-            </div>
+            <div class="col" />
           </div>
           <div class="row">
             <div class="col">
@@ -50,11 +32,8 @@
 </template>
 
 <script>
-import AdapterFactory from '../../adapters/adapter-factory'
 import WlModal from '../../components/wl-modal'
 import WlSuggest from '../../components/form/wl-suggest'
-
-const dashboardAdapter = AdapterFactory.get('DashboardAdapter')
 
 export default {
   components: {
@@ -94,9 +73,6 @@ export default {
   },
 
   computed: {
-    canEditTask () {
-      return this.projectId !== 0
-    }
   },
 
   methods: {
@@ -104,27 +80,6 @@ export default {
       this.showModal = true
     },
 
-    async loadSuggestions (keyword) {
-      return dashboardAdapter.getProjectSuggestionList(keyword)
-    },
-    async loadTaskSuggestions (keyword) {
-      return dashboardAdapter.getTaskSuggestionList(this.projectId, keyword)
-    },
-
-    handleProjectSelected (payload) {
-      this.projectId = payload.value
-      this.projectName = payload.text
-
-      if (this.projectId === 0) {
-        this.taskId = 0
-        this.taskName = ''
-        this.$refs.taskSuggest.init('', 0)
-      }
-    },
-    handleTaskSelected (payload) {
-      this.taskId = payload.value
-      this.taskName = payload.text
-    },
     handleSetProjectAndTask () {
       this.$emit('setProjectAndTask', {
         projectId: this.projectId,

--- a/resources/js/pages/dashboard/task-select.vue
+++ b/resources/js/pages/dashboard/task-select.vue
@@ -1,0 +1,155 @@
+<template>
+  <WlFrame size="xl">
+    <template slot="title">
+      現在のタスク
+    </template>
+    <template slot="body">
+      <div class="form form-align-left">
+        <div class="row">
+          <div class="col-label label-width-3">
+            プロジェクト名:
+          </div>
+          <div class="col input-width-2">
+            <WlSuggest
+              :value="activeProjectId"
+              :text="activeProjectName"
+              :suggest-callback="loadSuggestions"
+              @selected="handleProjectSelected"
+            />
+          </div>
+          <div class="col-label label-width-2">
+            タスク名:
+          </div>
+          <div class="col input-width-2">
+            <WlSuggest
+              ref="taskSuggest"
+              :value="activeTaskId"
+              :text="activeTaskName"
+              :suggest-callback="loadTaskSuggestionsCallback"
+              :disabled="!canEditTask"
+              @selected="handleTaskSelected"
+            />
+          </div>
+        </div>
+      </div>
+
+      <WlSubFrame size="s">
+        <template slot="title">
+          実績
+        </template>
+        <template slot="body">
+          <div class="form form-align-left">
+            <div class="row">
+              <div class="col-label label-width-2">
+                作業時間:
+              </div>
+              <div class="col input-width-2">
+                <input v-model="resultHours" type="number" class="text-box" size="5" :disabled="!canInputResult"> min
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-label label-width-2">
+                メモ:
+              </div>
+              <div class="col input-width-2">
+                <textarea v-model="resultMemo" class="text-box" style="width: 90%; height: 60px;" :disabled="!canInputResult" />
+              </div>
+            </div>
+            <div class="row row-align-right">
+              <button class="button" :disabled="!canRegisterResult" @click="handleRegisterResult">
+                登録
+              </button>
+            </div>
+          </div>
+        </template>
+      </WlSubFrame>
+    </template>
+  </Wlframe>
+</template>
+
+<script>
+
+import WlFrame from '../../components/wl-frame'
+import WlSubFrame from '../../components/wl-sub-frame'
+import WlSuggest from '../../components/form/wl-suggest'
+
+export default {
+
+  components: {
+    WlFrame,
+    WlSubFrame,
+    WlSuggest
+  },
+
+  props: {
+    loadSuggestions: {
+      type: Function,
+      required: true
+    },
+    loadTaskSuggestions: {
+      type: Function,
+      required: true
+    }
+
+  },
+
+  data () {
+    return {
+      activeProjectId: 0,
+      activeTaskId: 0,
+      activeProjectName: '',
+      activeTaskName: '',
+      resultHours: 0.0,
+      resultMemo: '',
+
+    }
+  },
+
+  computed: {
+    canInputResult () {
+      return this.activeTaskId !== 0
+    },
+    canRegisterResult () {
+      return this.activeTaskId !== 0 && this.resultHours > 0
+    },
+    canEditTask () {
+      return this.activeProjectId !== 0
+    }
+  },
+
+  methods: {
+    handleProjectSelected (payload) {
+      this.activeProjectId = payload.value
+      this.activeProjectName = payload.text
+
+      if (this.activeProjectId === 0) {
+        this.activeTaskId = 0
+        this.activeTaskName = ''
+        this.$refs.taskSuggest.init('', 0)
+      }
+    },
+    handleTaskSelected (payload) {
+      this.activeTaskId = payload.value
+      this.activeTaskName = payload.text
+    },
+    async loadTaskSuggestionsCallback (keyword) {
+      return await this.loadTaskSuggestions(this.activeProjectId, keyword)
+    },
+
+    async handleRegisterResult () {
+      const done = () => {
+        this.resultHours = 0
+        this.resultMemo = ''
+      }
+      this.$emit('register-result', {
+        taskId: this.activeTaskId,
+        resultHours: this.resultHours,
+        resultMemo: this.resultMemo,
+      }, done)
+    }
+
+  },
+
+}
+
+</script>

--- a/resources/js/pages/dashboard/task-select.vue
+++ b/resources/js/pages/dashboard/task-select.vue
@@ -14,6 +14,7 @@
               :value="activeProjectId"
               :text="activeProjectName"
               :suggest-callback="loadSuggestions"
+              data-test="project-input"
               @selected="handleProjectSelected"
             />
           </div>
@@ -27,6 +28,7 @@
               :text="activeTaskName"
               :suggest-callback="loadTaskSuggestionsCallback"
               :disabled="!canEditTask"
+              data-test="task-input"
               @selected="handleTaskSelected"
             />
           </div>
@@ -44,7 +46,14 @@
                 作業時間:
               </div>
               <div class="col input-width-2">
-                <input v-model="resultHours" type="number" class="text-box" size="5" :disabled="!canInputResult"> min
+                <input
+                  v-model="resultHours"
+                  type="number"
+                  class="text-box"
+                  data-test="result-hours"
+                  size="5"
+                  :disabled="!canInputResult"
+                > min
               </div>
             </div>
             <div class="row">
@@ -52,11 +61,17 @@
                 メモ:
               </div>
               <div class="col input-width-2">
-                <textarea v-model="resultMemo" class="text-box" style="width: 90%; height: 60px;" :disabled="!canInputResult" />
+                <textarea
+                  v-model="resultMemo"
+                  class="text-box"
+                  data-test="result-memo"
+                  style="width: 90%; height: 60px;"
+                  :disabled="!canInputResult"
+                />
               </div>
             </div>
             <div class="row row-align-right">
-              <button class="button" :disabled="!canRegisterResult" @click="handleRegisterResult">
+              <button class="button" :disabled="!canRegisterResult" data-test="register-button" @click="handleRegisterResult">
                 登録
               </button>
             </div>

--- a/resources/js/pages/dashboard/task-select.vue
+++ b/resources/js/pages/dashboard/task-select.vue
@@ -125,7 +125,7 @@ export default {
       return this.activeTaskId !== 0
     },
     canRegisterResult () {
-      return this.activeTaskId !== 0 && this.resultHours > 0
+      return this.activeTaskId !== 0 && this.resultHours > 0 && this.resultMemo !== ''
     },
     canEditTask () {
       return this.activeProjectId !== 0

--- a/tests/js/pages/dashboard/task-select.spec.js
+++ b/tests/js/pages/dashboard/task-select.spec.js
@@ -1,0 +1,107 @@
+import TaskSelect from '@/pages/dashboard/task-select'
+import flushPromises from 'flush-promises'
+import { mount } from '@vue/test-utils'
+
+describe('TaskSelect', () => {
+  const createTaskSelect = (loadSuggestions = null, loadTaskSuggestions = null) => {
+    if (!loadSuggestions) {
+      loadSuggestions = keyword => []
+    }
+    if (!loadTaskSuggestions) {
+      loadTaskSuggestions = keyword => []
+    }
+    return mount(TaskSelect, {
+      propsData: {
+        loadSuggestions,
+        loadTaskSuggestions
+      }
+    })
+  }
+
+  /**
+   * 指定した名前のプロジェクトを選択する
+   */
+  const selectProject = async (wrapper, projectName) => {
+    wrapper.find('[data-test="project-input"]').trigger('click')
+    await flushPromises()
+    wrapper.find('[data-test="project-input"] input[type="text"]').element.value = projectName
+    wrapper.find('[data-test="project-input"] input[type="text"]').trigger('input')
+    await flushPromises()
+
+    const items = wrapper.findAll('[data-test="project-input"] li')
+    items.wrappers.forEach((item) => {
+      if (item.text() === projectName) {
+        item.trigger('click')
+      }
+    })
+    await flushPromises()
+  }
+
+  /**
+   * 指定した名前のタスクを選択する
+   * (プロジェクトは選択済の想定)
+   */
+  const selectTask = async (wrapper, taskName) => {
+    wrapper.find('[data-test="task-input"]').trigger('click')
+    await flushPromises()
+    wrapper.find('[data-test="task-input"] input[type="text"]').element.value = taskName
+    wrapper.find('[data-test="task-input"] input[type="text"]').trigger('input')
+    await flushPromises()
+
+    const items = wrapper.findAll('[data-test="task-input"] li')
+    items.wrappers.forEach((item) => {
+      if (item.text() === taskName) {
+        item.trigger('click')
+      }
+    })
+    await flushPromises()
+  }
+
+  describe('初期状態', () => {
+    test('プロジェクト名以外は入力不可になっていること', async () => {
+      const wrapper = createTaskSelect()
+      expect(wrapper.find('[data-test="project-input"]').exists()).toBeTruthy()
+      expect(wrapper.find('[data-test="project-input"]').props()).not.toMatchObject({ disabled: true })
+      expect(wrapper.find('[data-test="task-input"]').props()).toMatchObject({ disabled: true })
+      expect(wrapper.find('[data-test="result-hours"]').element.disabled).toBeTruthy()
+      expect(wrapper.find('[data-test="result-memo"]').element.disabled).toBeTruthy()
+      expect(wrapper.find('[data-test="register-button"]').element.disabled).toBeTruthy()
+    })
+
+    // プロジェクト名を渡した場合、タスク名まで入力できる
+    test('プロジェクト名を設定した場合、タスク名まで入力できる', async () => {
+      const projectSuggestFunction = keyword => [{ id: 1, name: 'Project1' }]
+      const wrapper = createTaskSelect(projectSuggestFunction)
+
+      await selectProject(wrapper, 'Project1')
+
+      expect(wrapper.find('[data-test="project-input"] .selected-text').text()).toBe('Project1')
+      expect(wrapper.find('[data-test="task-input"]').props()).not.toMatchObject({ disabled: true })
+    })
+
+    // タスク名まで渡した場合、実績の入力が出来る
+    test('タスク名まで設定した場合、実績の入力が出来る', async () => {
+      const projectSuggestFunction = keyword => [{ id: 1, name: 'Project1' }]
+      const taskSuggestFunction = keyword => [{ id: 1, name: 'Task1' }]
+      const wrapper = createTaskSelect(projectSuggestFunction, taskSuggestFunction)
+
+      await selectProject(wrapper, 'Project1')
+      await selectTask(wrapper, 'Task1')
+
+      expect(wrapper.find('[data-test="task-input"] .selected-text').text()).toBe('Task1')
+      expect(wrapper.find('[data-test="result-hours"]').element.disabled).toBeFalsy()
+      expect(wrapper.find('[data-test="result-memo"]').element.disabled).toBeFalsy()
+    })
+  })
+
+  describe('タスク選択欄', () => {
+    // タスクを選択解除しても、プロジェクトには影響しない
+    // タスクを選択解除すると、実績は登録できなくなる
+  })
+
+  describe('実績入力欄', () => {
+    // 作業時間は未入力不可
+    // メモ欄も未入力不可
+    //
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,6 +5680,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"


### PR DESCRIPTION
DashboardContainerに実装を移す部分まで対応。